### PR TITLE
Fixed execSync error for Windows users

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const execSync = require('child_process').execSync;
+const spawnSync = require('child_process').spawnSync;
 const BroccoliPlugin = require('broccoli-plugin');
 const path = require('path');
 const MergeTrees = require('broccoli-merge-trees');
@@ -25,7 +25,7 @@ class MyPlugin extends BroccoliPlugin {
     let modulesFile = path.join(tailwindPath, 'config', 'modules.css');
     let outputFile = path.join(this.outputPath, 'app', 'styles', 'tailwind.css');
 
-    execSync(`${tailwindBinary} build ${modulesFile} -c ${configFile} -o ${outputFile}`);
+    spawnSync(`"${tailwindBinary}" build ${modulesFile} -c ${configFile} -o ${outputFile}`);
   }
 }
 


### PR DESCRIPTION
That one was a little tricky but the crux of the explanation is [here (node docs)](https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows).

I swapped out `execSync` for `spawnSync` and I think it maintains the original intent but circumvents the issue on Windows, but let me know what you think.

Summary seems to be:
- `exec` attempts to spawn a "subshell" which Windows sucks at
- `spawn` happens inside a new process but doesn't have the affordances of a shell (piping, redirects, etc...)

So since the Broccoli plugin is just calling the single tailwind binary then I think this works for now. 

Apologies if you were already aware of all this!