### PR TITLE
Handle addon/dummy/app build steps with config variables

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,10 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
+
+    'ember-cli-tailwind': {
+      buildTarget: 'dummy'
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ module.exports = {
 
     if (includer.trees) {
       this.projectType = 'app';
-      this.tailwindInputPath = this._getInputPath(this.project.root, includer.trees.app);
     } else if (includer.treePaths) {
+      this.tailwindInputPath = this._getInputPath(this.project.root, 'app');
       this.projectType = 'addon';
-      this.tailwindInputPath = this._getInputPath(includer.root, includer.treePaths.addon);
+      this.tailwindInputPath = this._getInputPath(this.project.root, 'addon');
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,23 @@ const path = require('path');
 const Rollup = require('broccoli-rollup');
 const BuildTailwindPlugin = require('./lib/build-tailwind-plugin');
 
+const buildDestinations = {
+  dummy: {
+    path: 'tests/dummy/app',
+    type: 'app'
+  },
+  app: {
+    path: 'app',
+    type: 'app'
+  },
+  addon: {
+    path: 'addon',
+    type: 'addon'
+  }
+};
+
+const validBuildTargets = Object.keys(buildDestinations);
+
 module.exports = {
   name: 'ember-cli-tailwind',
 
@@ -15,16 +32,15 @@ module.exports = {
 
   included(includer) {
     this._super.included.apply(this, arguments);
-
-    this.import('vendor/etw.css');
-
-    if (!this.isAddon()) {
-      this.projectType = 'app';
-      this.tailwindInputPath = this._getInputPath(this.project.root, 'app');
-    } else {
-      this.projectType = 'addon';
-      this.tailwindInputPath = this._getInputPath(this.project.root, 'addon');
+    
+    let buildTarget = includer.options['ember-cli-tailwind']['buildTarget'];
     }
+    let buildConfig = buildDestinations[buildTarget];
+    
+    this.import('vendor/etw.css');
+    
+    this.projectType = buildConfig.type;
+    this.tailwindInputPath = this._getInputPath(this.project.root, buildConfig.path);
   },
 
   treeForStyles() {

--- a/index.js
+++ b/index.js
@@ -28,9 +28,11 @@ module.exports = {
   included(includer) {
     this._super.included.apply(this, arguments);
     
-    let buildTarget = includer.options['ember-cli-tailwind']['buildTarget'];
-    
     if (!this._validateBuildTarget(buildTarget)) {
+    let buildTarget = includer.options &&
+      includer.options['ember-cli-tailwind'] &&
+      includer.options['ember-cli-tailwind']['buildTarget'];
+
       return;
     }
     

--- a/index.js
+++ b/index.js
@@ -8,15 +8,20 @@ const BuildTailwindPlugin = require('./lib/build-tailwind-plugin');
 module.exports = {
   name: 'ember-cli-tailwind',
 
+  isAddon() {
+    const keywords = this.project.pkg.keywords;
+    return (keywords && keywords.indexOf('ember-addon') !== -1);
+  },
+
   included(includer) {
     this._super.included.apply(this, arguments);
 
     this.import('vendor/etw.css');
 
-    if (includer.trees) {
+    if (!this.isAddon()) {
       this.projectType = 'app';
-    } else if (includer.treePaths) {
       this.tailwindInputPath = this._getInputPath(this.project.root, 'app');
+    } else {
       this.projectType = 'addon';
       this.tailwindInputPath = this._getInputPath(this.project.root, 'addon');
     }

--- a/index.js
+++ b/index.js
@@ -27,12 +27,12 @@ module.exports = {
 
   included(includer) {
     this._super.included.apply(this, arguments);
-    
-    if (!this._validateBuildTarget(buildTarget)) {
+
     let buildTarget = includer.options &&
       includer.options['ember-cli-tailwind'] &&
       includer.options['ember-cli-tailwind']['buildTarget'];
 
+    if (!this._validateBuildTarget(buildTarget, includer)) {
       return;
     }
     
@@ -92,7 +92,7 @@ module.exports = {
     });
   },
 
-  _validateBuildTarget(buildTarget) {
+  _validateBuildTarget(buildTarget, includer) {
     if (!buildTarget) {
       this.ui.writeWarnLine('You must specify a buildTarget using an ember-cli-tailwind config object in your app or addon.')
       return false;
@@ -103,7 +103,7 @@ module.exports = {
       return false;
     }
 
-    if (this._tailwindAddonConfigExists() && !this._isDependency()) {
+    if (this._tailwindAddonConfigExists(includer) && !this._isDependency(includer)) {
       this.ui.writeError('A Tailwind config was detected in the addon folder, but `ember-cli-tailwind` is not listed as a dependency. Please make sure `ember-cli-tailwind` is listed in `dependencies` (NOT `devDependencies`).');
       return false;
     }
@@ -111,18 +111,13 @@ module.exports = {
     return true;
   },
 
-  _tailwindAddonConfigExists() {
-    return fs.existsSync(path.join(this.project.root, 'addon', 'tailwind'));
-  },
-
-  _isAddon() {
-    const keywords = this.project.pkg.keywords;
-    return (keywords && keywords.indexOf('ember-addon') !== -1);
+  _tailwindAddonConfigExists(includer) {
+    return fs.existsSync(path.join(includer.project.root, 'addon', 'tailwind'));
   },
 
   // Check that `ember-cli-tailwind` is listed in `dependencies` (as opposed to `devDependencies`)
-  _isDependency() {
-    let deps = this.project.pkg.dependencies;
+  _isDependency(includer) {
+    let deps = includer.project.pkg.dependencies;
 
     return Object.keys(deps).includes(this.name);
   }

--- a/index.js
+++ b/index.js
@@ -25,16 +25,15 @@ const validBuildTargets = Object.keys(buildDestinations);
 module.exports = {
   name: 'ember-cli-tailwind',
 
-  isAddon() {
-    const keywords = this.project.pkg.keywords;
-    return (keywords && keywords.indexOf('ember-addon') !== -1);
-  },
-
   included(includer) {
     this._super.included.apply(this, arguments);
     
     let buildTarget = includer.options['ember-cli-tailwind']['buildTarget'];
+    
+    if (!this._validateBuildTarget(buildTarget)) {
+      return;
     }
+    
     let buildConfig = buildDestinations[buildTarget];
     
     this.import('vendor/etw.css');
@@ -62,7 +61,7 @@ module.exports = {
       this.ui.writeWarnLine('Unable to process Tailwind styles for a non-string tree');
       return;
     }
-
+    
     let fullPath = path.join(root, inputPath, 'tailwind');
     if (fs.existsSync(path.join(fullPath, 'config', 'tailwind.js'))) {
       return fullPath;
@@ -89,6 +88,40 @@ module.exports = {
       srcFile: path.join('config', 'modules.css'),
       destFile: path.join(basePath, 'tailwind.css')
     });
-  }
+  },
 
+  _validateBuildTarget(buildTarget) {
+    if (!buildTarget) {
+      this.ui.writeWarnLine('You must specify a buildTarget using an ember-cli-tailwind config object in your app or addon.')
+      return false;
+    }
+    
+    if (!validBuildTargets.includes(buildTarget)) {
+      this.ui.writeWarnLine('Your buildTarget is invalid. Valid targets are "app", "addon", or "dummy".')
+      return false;
+    }
+
+    if (this._tailwindAddonConfigExists() && !this._isDependency()) {
+      this.ui.writeError('A Tailwind config was detected in the addon folder, but `ember-cli-tailwind` is not listed as a dependency. Please make sure `ember-cli-tailwind` is listed in `dependencies` (NOT `devDependencies`).');
+      return false;
+    }
+    
+    return true;
+  },
+
+  _tailwindAddonConfigExists() {
+    return fs.existsSync(path.join(this.project.root, 'addon', 'tailwind'));
+  },
+
+  _isAddon() {
+    const keywords = this.project.pkg.keywords;
+    return (keywords && keywords.indexOf('ember-addon') !== -1);
+  },
+
+  // Check that `ember-cli-tailwind` is listed in `dependencies` (as opposed to `devDependencies`)
+  _isDependency() {
+    let deps = this.project.pkg.dependencies;
+
+    return Object.keys(deps).includes(this.name);
+  }
 };

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
     this.import('vendor/etw.css');
     
     this.projectType = buildConfig.type;
-    this.tailwindInputPath = this._getInputPath(this.project.root, buildConfig.path);
+    this.tailwindInputPath = this._getInputPath(this.parent.root, buildConfig.path);
   },
 
   treeForStyles() {
@@ -92,18 +92,18 @@ module.exports = {
     });
   },
 
-  _validateBuildTarget(buildTarget, includer) {
+  _validateBuildTarget(buildTarget) {
     if (!buildTarget) {
       this.ui.writeWarnLine('You must specify a buildTarget using an ember-cli-tailwind config object in your app or addon.')
       return false;
     }
     
-    if (!validBuildTargets.includes(buildTarget)) {
+    if (buildTarget && !validBuildTargets.includes(buildTarget)) {
       this.ui.writeWarnLine('Your buildTarget is invalid. Valid targets are "app", "addon", or "dummy".')
       return false;
     }
 
-    if (this._tailwindAddonConfigExists(includer) && !this._isDependency(includer)) {
+    if (this._tailwindAddonConfigExists() && !this._isDependency()) {
       this.ui.writeError('A Tailwind config was detected in the addon folder, but `ember-cli-tailwind` is not listed as a dependency. Please make sure `ember-cli-tailwind` is listed in `dependencies` (NOT `devDependencies`).');
       return false;
     }
@@ -111,13 +111,13 @@ module.exports = {
     return true;
   },
 
-  _tailwindAddonConfigExists(includer) {
-    return fs.existsSync(path.join(includer.project.root, 'addon', 'tailwind'));
+  _tailwindAddonConfigExists() {
+    return fs.existsSync(path.join(this.parent.root, 'addon', 'tailwind'));
   },
 
   // Check that `ember-cli-tailwind` is listed in `dependencies` (as opposed to `devDependencies`)
-  _isDependency(includer) {
-    let deps = includer.project.pkg.dependencies;
+  _isDependency() {
+    let deps = this.parent.pkg.dependencies;
 
     return Object.keys(deps).includes(this.name);
   }

--- a/index.js
+++ b/index.js
@@ -93,8 +93,15 @@ module.exports = {
   },
 
   _validateBuildTarget(buildTarget) {
+    // If no build target is found, but we're not in addon, assume something is definitely wrong
+    // and print the warning line so app consumers won't be in the dark about their styles not
+    // showing up. On the other hand, if it IS an addon, don't print the warning message since
+    // since this hook will be run twice regardless of whether or not they're intending to use
+    // tailwind in both their addon and dummy app.
     if (!buildTarget) {
-      this.ui.writeWarnLine('You must specify a buildTarget using an ember-cli-tailwind config object in your app or addon.')
+      if (!this._isAddon()) {
+        this.ui.writeWarnLine('You must specify a buildTarget using an ember-cli-tailwind config object in your app or addon.')
+      }
       return false;
     }
     
@@ -109,6 +116,11 @@ module.exports = {
     }
     
     return true;
+  },
+
+  _isAddon() {
+    const keywords = this.parent.pkg.keywords;
+    return (keywords && keywords.indexOf('ember-addon') !== -1);
   },
 
   _tailwindAddonConfigExists() {


### PR DESCRIPTION
This PR addresses the issue discovered in https://github.com/embermap/ember-cli-tailwind/issues/10.

The addon was originally using the presence/absence of `trees` and `treePaths` on the including entity to determine whether or not it should be treated as an addon or app, and, in turn, what the output paths for the vendor files ought to be.

Unfortunately, in Ember 3.0, `trees` and `treePaths` were changed and so this check no longer worked.

To fix this, this PR moves `ember-cli-tailwind` to using an explicit configuration rather than auto-detection strategy. In order to include tailwind in your app, you must now add a `buildTarget` option under the `ember-cli-tailwind` property in your app or addon's configuration. Valid `buildTarget` values are `app`, `addon`, and `dummy`.

For example, to use tailwind in an addon to style BOTH the addon and the dummy app, you would 
need the following:

In `ember-cli-build.js`:
```js

module.exports = function(defaults) {
  let app = new EmberAddon(defaults, {
    // Add options here

    'ember-cli-tailwind': {
      buildTarget: 'dummy'
    }
  });
```

In `index.js`:
```js
module.exports = {
  name: 'tailwind-dummy-app-test',

  options: {
    'ember-cli-tailwind': {
      buildTarget: 'addon'
    }
  }
};
```

