### PR TITLE
update ember-string-helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-string-utils": "^1.1.0",
     "ember-composable-helpers": "^2.1.0",
-    "ember-string-helpers": "^1.0.2",
+    "ember-string-helpers": "^1.8.1",
     "ember-truth-helpers": "^2.0.0",
     "fs-extra": "^5.0.0",
     "jsdom": "^11.6.2",


### PR DESCRIPTION
This gets rid of the error:

```
DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6. Version 5.2.8 located: your-addon -> ember-cli-addon-docs -> ember-cli-tailwind -> ember-string-helpers -> ember-cli-babel
```