### PR TITLE
If `!shouldIncludeStyleguide`, exclude the instance initializer

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
     if (!this._validateBuildTarget(buildTarget, includer)) {
       return;
     }
-    
+
     let buildConfig = buildDestinations[buildTarget];
 
     if (this._shouldIncludeStyleguide()) {
@@ -61,12 +61,14 @@ module.exports = {
 
   treeForApp(tree) {
     let appTree = this._super(tree);
-    if (this._shouldIncludeStyleguide()) {
-      return appTree;
-    } 
-    return new Funnel(appTree, {
-      exclude: ['**/instance-initializers/ember-cli-tailwind.js'],
-    });
+
+    if (!this._shouldIncludeStyleguide()) {
+      appTree = new Funnel(appTree, {
+        exclude: ['**/instance-initializers/ember-cli-tailwind.js'],
+      });
+    }
+
+    return appTree;
   },
 
   _shouldIncludeStyleguide() {
@@ -82,7 +84,7 @@ module.exports = {
       this.ui.writeWarnLine('Unable to process Tailwind styles for a non-string tree');
       return;
     }
-    
+
     let fullPath = path.join(root, inputPath, 'tailwind');
     if (fs.existsSync(path.join(fullPath, 'config', 'tailwind.js'))) {
       return fullPath;
@@ -123,7 +125,7 @@ module.exports = {
       }
       return false;
     }
-    
+
     if (buildTarget && !validBuildTargets.includes(buildTarget)) {
       this.ui.writeWarnLine('Your buildTarget is invalid. Valid targets are "app", "addon", or "dummy".')
       return false;
@@ -133,7 +135,7 @@ module.exports = {
       this.ui.writeError('A Tailwind config was detected in the addon folder, but `ember-cli-tailwind` is not listed as a dependency. Please make sure `ember-cli-tailwind` is listed in `dependencies` (NOT `devDependencies`).');
       return false;
     }
-    
+
     return true;
   },
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const Funnel = require('broccoli-funnel');
 const Rollup = require('broccoli-rollup');
 const BuildTailwindPlugin = require('./lib/build-tailwind-plugin');
 
@@ -56,6 +57,16 @@ module.exports = {
     if (this.projectType === 'addon' && this._hasTailwindConfig()) {
       return this._buildTailwind();
     }
+  },
+
+  treeForApp(tree) {
+    let appTree = this._super(tree);
+    if (this._shouldIncludeStyleguide()) {
+      return appTree;
+    } 
+    return new Funnel(appTree, {
+      exclude: ['**/instance-initializers/ember-cli-tailwind.js'],
+    });
   },
 
   _shouldIncludeStyleguide() {

--- a/node-tests/import-files-test.js
+++ b/node-tests/import-files-test.js
@@ -1,4 +1,5 @@
 /* eslint-env node */
+let { createBuilder } = require('broccoli-test-helper');
 let expect = require('chai').expect;
 let EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 let _ = require('lodash');
@@ -9,7 +10,7 @@ describe('import files', function() {
   });
 
   ['development', 'test'].forEach(environment => {
-    it(`includes styleguide styles by default in non-production environments (${environment})`, () => {
+    it(`includes styleguide styles by default in non-production environments (${environment})`, async () => {
       process.env.EMBER_ENV = environment;
       let addon = new EmberAddon({}, {
         'ember-cli-tailwind': {
@@ -17,10 +18,16 @@ describe('import files', function() {
         }
       });
       expect(_.values(addon._styleOutputFiles)[0]).to.include('vendor/etw.css');
+
+      let output = createBuilder(addon._processedAppTree());
+      await output.build();
+      expect(output.read()).to.have.nested.property(
+        'dummy.instance-initializers.ember-cli-tailwind\\.js'
+      );
     });
   })
 
-  it('excludes styleguide styles by default in the production environment', () => {
+  it('excludes styleguide styles by default in the production environment', async () => {
     process.env.EMBER_ENV = 'production';
     let addon = new EmberAddon({}, {
       'ember-cli-tailwind': {
@@ -28,11 +35,17 @@ describe('import files', function() {
       }
     });
     expect(_.values(addon._styleOutputFiles)[0]).to.not.include('vendor/etw.css');
+
+    let output = createBuilder(addon._processedAppTree());
+    await output.build();
+    expect(output.read()).not.to.have.nested.property(
+      'dummy.instance-initializers.ember-cli-tailwind\\.js'
+    );
   });
 
   describe('shouldIncludeStyleguide', function() {
     ['development', 'test', 'production'].forEach(environment => {
-      it(`includes styleguide styles when enabled (${environment})`, () => {
+      it(`includes styleguide styles when enabled (${environment})`, async () => {
         process.env.EMBER_ENV = environment
         let addon = new EmberAddon({}, {
           'ember-cli-tailwind': {
@@ -41,11 +54,17 @@ describe('import files', function() {
           configPath: 'tests/fixtures/config/environment-styleguide-enabled'
         });
         expect(_.values(addon._styleOutputFiles)[0]).to.include('vendor/etw.css');
+
+        let output = createBuilder(addon._processedAppTree());
+        await output.build();
+        expect(output.read()).to.have.nested.property(
+          'dummy.instance-initializers.ember-cli-tailwind\\.js'
+        );
       });
     });
 
     ['development', 'test', 'production'].forEach(environment => {
-      it(`excludes styleguide styles when disabled (${environment})`, () => {
+      it(`excludes styleguide styles when disabled (${environment})`, async () => {
         process.env.EMBER_ENV = environment
         let addon = new EmberAddon({}, {
           'ember-cli-tailwind': {
@@ -54,6 +73,12 @@ describe('import files', function() {
           configPath: 'tests/fixtures/config/environment-styleguide-disabled'
         });
         expect(_.values(addon._styleOutputFiles)[0]).to.not.include('vendor/etw.css');
+
+        let output = createBuilder(addon._processedAppTree());
+        await output.build();
+        expect(output.read()).not.to.have.nested.property(
+          'dummy.instance-initializers.ember-cli-tailwind\\.js'
+        );
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "broccoli-test-helper": "^1.2.0",
     "chai": "^4.1.2",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~2.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,6 +1248,10 @@ broccoli-middleware@^1.0.0:
     handlebars "^4.0.4"
     mime "^1.2.11"
 
+broccoli-node-info@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz#3aa2e31e07e5bdb516dd25214f7c45ba1c459412"
+
 broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.0, broccoli-persistent-filter@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz#3511bc52fc53740cda51621f58a28152d9911bc1"
@@ -1299,6 +1303,10 @@ broccoli-rollup@^2.0.0:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.1"
 
+broccoli-slow-trees@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-2.0.0.tgz#9741afe992787add64aec7f7c8211dfcc058278d"
+
 broccoli-slow-trees@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-3.0.1.tgz#9bf2a9e2f8eb3ed3a3f2abdde988da437ccdc9b4"
@@ -1338,6 +1346,17 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.5.0:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
+broccoli-test-helper@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/broccoli-test-helper/-/broccoli-test-helper-1.2.0.tgz#d01005d8611fd73ebe1b29552bf052ff59badfb4"
+  dependencies:
+    broccoli "^1.1.0"
+    fixturify "^0.3.2"
+    fs-tree-diff "^0.5.6"
+    mktemp "^0.4.0"
+    rimraf "^2.5.4"
+    walk-sync "^0.3.1"
+
 broccoli-uglify-sourcemap@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.2.tgz#f4a73112f1f56b46043e2e89cba5ce7762cddeb3"
@@ -1358,6 +1377,26 @@ broccoli-writer@~0.1.1:
   dependencies:
     quick-temp "^0.1.0"
     rsvp "^3.0.6"
+
+broccoli@^1.1.0:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-1.1.4.tgz#b023b028b866f447ed14341007961efd03f7251c"
+  dependencies:
+    broccoli-node-info "1.1.0"
+    broccoli-slow-trees "2.0.0"
+    broccoli-source "^1.1.0"
+    commander "^2.5.0"
+    connect "^3.3.3"
+    copy-dereference "^1.0.0"
+    findup-sync "^1.0.0"
+    handlebars "^4.0.4"
+    heimdalljs-logger "^0.1.7"
+    mime "^1.2.11"
+    rimraf "^2.4.3"
+    rsvp "^3.5.0"
+    sane "^1.4.1"
+    tmp "0.0.31"
+    underscore.string "^3.2.2"
 
 browser-process-hrtime@^0.1.2:
   version "0.1.2"
@@ -1717,6 +1756,10 @@ commander@^2.11.0, commander@^2.6.0, commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
+commander@^2.5.0:
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
+
 comment-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/comment-regex/-/comment-regex-1.0.0.tgz#7dd70268c83648a9c4cc19bf472d52e64f63918d"
@@ -1783,6 +1826,15 @@ configstore@^3.0.0:
     unique-string "^1.0.0"
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
+
+connect@^3.3.3:
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.6.6.tgz#09eff6c55af7236e137135a72574858b6786f524"
+  dependencies:
+    debug "2.6.9"
+    finalhandler "1.1.0"
+    parseurl "~1.3.2"
+    utils-merge "1.0.1"
 
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
@@ -3060,6 +3112,15 @@ findup-sync@^0.4.2:
     micromatch "^2.3.7"
     resolve-dir "^0.1.0"
 
+findup-sync@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-1.0.0.tgz#6f7e4b57b6ee3a4037b4414eaedea3f58f71e0ec"
+  dependencies:
+    detect-file "^0.1.0"
+    is-glob "^2.0.1"
+    micromatch "^2.3.7"
+    resolve-dir "^0.1.0"
+
 fireworm@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/fireworm/-/fireworm-0.7.1.tgz#ccf20f7941f108883fcddb99383dbe6e1861c758"
@@ -3069,6 +3130,13 @@ fireworm@^0.7.0:
     lodash.debounce "^3.1.1"
     lodash.flatten "^3.0.2"
     minimatch "^3.0.2"
+
+fixturify@^0.3.2:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-0.3.4.tgz#c676de404a7f8ee8e64d0b76118e62ec95ab7b25"
+  dependencies:
+    fs-extra "^0.30.0"
+    matcher-collection "^1.0.4"
 
 flat-cache@^1.2.1:
   version "1.3.0"
@@ -4617,7 +4685,7 @@ markdown-it@^8.3.0, markdown-it@^8.3.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.3"
 
-matcher-collection@^1.0.0, matcher-collection@^1.0.5:
+matcher-collection@^1.0.0, matcher-collection@^1.0.4, matcher-collection@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.5.tgz#2ee095438372cb8884f058234138c05c644ec339"
   dependencies:
@@ -4788,7 +4856,7 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mktemp@~0.4.0:
+mktemp@^0.4.0, mktemp@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
 
@@ -5858,7 +5926,7 @@ safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
 
-sane@^1.1.1:
+sane@^1.1.1, sane@^1.4.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-1.7.0.tgz#b3579bccb45c94cf20355cc81124990dfd346e30"
   dependencies:
@@ -6510,6 +6578,12 @@ tmp@0.0.28:
   dependencies:
     os-tmpdir "~1.0.1"
 
+tmp@0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 tmp@^0.0.29:
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
@@ -6648,7 +6722,7 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
-underscore.string@~3.3.4:
+underscore.string@^3.2.2, underscore.string@~3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
   dependencies:


### PR DESCRIPTION
I tried using this addon in an engine, and the instance initializer's [`import Router from '../router';`](https://github.com/embermap/ember-cli-tailwind/blob/master/app/instance-initializers/ember-cli-tailwind.js#L1) would error because there is no router there.

I'm not sure the best way to make this fully support engines, but best I could tell the instance initializer is only relevant when the styleguide is enabled. This PR excludes the instance initializer from the app tree if `shouldIncludeStyleguide` is false, which means it *can* be used in engines, at least.