### PR TITLE
Fix a problem with the styleguide not rendering properly

### DIFF
--- a/app/components/etw/module-section.js
+++ b/app/components/etw/module-section.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: '',
+});


### PR DESCRIPTION
This fixes a problem with the styleguide rendering a blank page. The problem occurs if you install ember-cli-tailwind inside a project which has the template-only-glimmer-components feature enabled. This changes the way the template is handled. {{namedArgument}} is undefined, unless you use the {{@namedArgument}} syntax.

Should fix #63 