### PR TITLE
configurable output file name

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,8 @@ module.exports = {
       this.import('vendor/etw.css');
     }
 
+    this.outputFile = this._getOutputFileName();
+
     this.projectType = buildConfig.type;
     this.tailwindInputPath = this._getInputPath(this.parent.root, buildConfig.path);
   },
@@ -124,8 +126,12 @@ module.exports = {
 
   _shouldBuildTailwind() {
     let shouldBuildTailwind = this._config().shouldBuildTailwind;
-
     return (shouldBuildTailwind !== undefined) ? shouldBuildTailwind : true;
+  },
+
+  _getOutputFileName() {
+    let customOutputFileName = this._config().outputFileName;
+    return (customOutputFileName !== undefined) ? customOutputFileName : 'tailwind.css';
   },
 
   _validateBuildTarget(buildTarget) {

--- a/lib/build-tailwind.js
+++ b/lib/build-tailwind.js
@@ -21,6 +21,7 @@ module.exports = function(addon) {
     tailwindAddon = addon.findOwnAddonByName('ember-cli-tailwind');
   }
   let inputPath = tailwindAddon.tailwindInputPath;
+  let outputFile = tailwindAddon.outputFile;
 
   let tailwindConfigTree = new Rollup(inputPath, {
     rollup: {
@@ -36,8 +37,10 @@ module.exports = function(addon) {
     }
   });
 
+
   return new BuildTailwindPlugin([ inputPath, tailwindConfigTree ], {
     srcFile: 'modules.css',
+    outputFile,
     cacheInclude: [/.*\.(js|css)$/]
   });
 }
@@ -47,13 +50,14 @@ class BuildTailwindPlugin extends BroccoliPlugin {
   constructor(inputTrees, options) {
     super(inputTrees, options);
     this.srcFile = options.srcFile;
+    this.outputFile = options.outputFile;
     this.didBuild = options.didBuild;
   }
 
   build() {
     let modulesFile = path.join(this.inputPaths[0], this.srcFile);
     let configFile = path.join(this.inputPaths[1], 'tailwind-config.js');
-    let outputFile = path.join(this.outputPath, 'tailwind.css');
+    let outputFile = path.join(this.outputPath,  this.outputFile);
 
     return postcss([
       easyImport,


### PR DESCRIPTION
Allows us to configure the output file name, mainly so we can import the tailwind file into our SASS pipeline and use ```@extend``` from there to build our components.

Inspired by this comment https://github.com/embermap/ember-cli-tailwind/issues/7#issuecomment-375332148

```ember-cli-build.js
        'ember-cli-tailwind': {
            outputFileName: '_tailwind.scss',
        }
```